### PR TITLE
Add support for docstring

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,4 @@
     entry: python-doc
     language: python
     language_version: python3
-    files: '\.(rst)$'
+    files: '\.(rst|py)$'

--- a/pre_commit_all_the_way_down/python_doc.py
+++ b/pre_commit_all_the_way_down/python_doc.py
@@ -149,8 +149,9 @@ def apply_pre_commit_rst(
         code += "\n"
         code = apply_pre_commit_on_block(code, whitelist, skiplist)
         code = fake_dedent(code, len(min_indent))
+        code = code.strip()
         code = indent(code, min_indent)
-        return f'{match["before"]}{code.rstrip()}{trailing_ws}'
+        return f'{match["before"]}{code}{trailing_ws}'
 
     src = RST_RE.sub(_rst_match, src)
 

--- a/pre_commit_all_the_way_down/python_doc.py
+++ b/pre_commit_all_the_way_down/python_doc.py
@@ -159,7 +159,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument("filenames", nargs="*")
     parser.add_argument(
         "--whitelist",
-        nargs="+",
+        action="append",
         default=[],
         type=str,
         help="A whitelist of hook ids to run",

--- a/pre_commit_all_the_way_down/python_doc.py
+++ b/pre_commit_all_the_way_down/python_doc.py
@@ -134,7 +134,7 @@ def apply_pre_commit_on_str(src: str, fname: str, whitelist: Sequence[str]) -> s
                 code_lines.append(f"{head_ws}... {line}\n")
         return "".join(code_lines)
 
-    # src = RST_RE.sub(_rst_match, src)
+    src = RST_RE.sub(_rst_match, src)
     src = walk_ast_helper(_pycon_match, src)
 
     return src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = [
+  "setuptools>=19.6",
+  "wheel",
+]
+
+
+[tool.isort]
+profile = "black"
+combine_as_imports = true
+sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
+
+[tool.black]
+line-length = 88
+# note : 'py39' is not an available option as of black 19.10b0
+target-version = ['py36', 'py37', 'py38']


### PR DESCRIPTION
This adds support for fixing docstrings like
```python
def foo():
    """
    Example
    >>> import numpy as np
    ... x = np.zeros(10)
    ... for i in range(10):
    ...    x[i] = i
    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
    """
```