### PR TITLE
More useful error reporting

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies & package
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest pre-commit mypy
+        python -m pip install flake8 pytest pre-commit
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         python -m pip install .
     - name: Lint with flake8
@@ -37,5 +37,3 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: pytest
-    - name: Test with mypy
-      run: mypy

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies & package
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest pre-commit
+        python -m pip install flake8 pytest pre-commit mypy
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         python -m pip install .
     - name: Lint with flake8
@@ -36,5 +36,6 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
-      run: |
-        pytest
+      run: pytest
+    - name: Test with mypy
+      run: mypy

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,14 +26,8 @@ jobs:
     - name: Install dependencies & package
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest pre-commit
+        python -m pip install pytest pre-commit
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         python -m pip install .
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,7 @@ repos:
     rev: v1.17.0
     hooks:
     -   id: setup-cfg-fmt
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.812
+    hooks:
+    -   id: mypy

--- a/pre_commit_all_the_way_down/python_doc.py
+++ b/pre_commit_all_the_way_down/python_doc.py
@@ -347,7 +347,7 @@ def main(argv: Sequence[str] = None) -> int:
             filename,
             whitelist=args.whitelist,
             skiplist=args.skiplist,
-            write_back=False,
+            write_back=args.write_back,
         )
 
     return retv

--- a/pre_commit_all_the_way_down/python_doc.py
+++ b/pre_commit_all_the_way_down/python_doc.py
@@ -176,7 +176,7 @@ def apply_pre_commit_rst(
     whitelist: Sequence[str] = None,
     skiplist: Sequence[str] = None,
 ) -> Tuple[int, str, Sequence[Error]]:
-    errors = []
+    errors: Sequence[Error] = []
     ret = 0
 
     # The _*_match functions are adapted from
@@ -220,7 +220,7 @@ def apply_pre_commit_pydocstring(
     whitelist: Sequence[str] = None,
     skiplist: Sequence[str] = None,
 ) -> Tuple[int, str, Sequence[Error]]:
-    errors = []
+    errors: Sequence[Error] = []
     ret = 0
 
     def _pycon_match(match: Match[str]) -> str:

--- a/pre_commit_all_the_way_down/python_doc.py
+++ b/pre_commit_all_the_way_down/python_doc.py
@@ -37,8 +37,8 @@ TRAILING_NL_RE = re.compile(r"\n+\Z", re.MULTILINE)
 @dataclass
 class Context:
     filename: str
-    start: int = None
-    end: int = None
+    start: Optional[int] = None
+    end: Optional[int] = None
 
 
 @dataclass
@@ -52,8 +52,8 @@ class Error:
 def apply_pre_commit_on_block(
     block: str,
     context: Context,
-    whitelist: Sequence[str] = None,
-    skiplist: Sequence[str] = None,
+    whitelist: Optional[Sequence[str]] = None,
+    skiplist: Optional[Sequence[str]] = None,
 ) -> Tuple[int, str, Sequence[Error]]:
     """
     Fix a code block.

--- a/pre_commit_all_the_way_down/python_doc.py
+++ b/pre_commit_all_the_way_down/python_doc.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from textwrap import dedent, indent
-from typing import Callable, Match, Optional, Sequence, Tuple
+from typing import Callable, List, Match, Optional, Sequence, Tuple
 
 BLOCK_TYPES = "(code|code-block|sourcecode|ipython)"
 PY_LANGS = "(python|py|sage|python3|py3|numpy)"
@@ -54,7 +54,7 @@ def apply_pre_commit_on_block(
     context: Context,
     whitelist: Optional[Sequence[str]] = None,
     skiplist: Optional[Sequence[str]] = None,
-) -> Tuple[int, str, Sequence[Error]]:
+) -> Tuple[int, str, List[Error]]:
     """
     Fix a code block.
 
@@ -175,8 +175,8 @@ def apply_pre_commit_rst(
     *,
     whitelist: Sequence[str] = None,
     skiplist: Sequence[str] = None,
-) -> Tuple[int, str, Sequence[Error]]:
-    errors: Sequence[Error] = []
+) -> Tuple[int, str, List[Error]]:
+    errors: List[Error] = []
     ret = 0
 
     # The _*_match functions are adapted from
@@ -219,8 +219,8 @@ def apply_pre_commit_pydocstring(
     *,
     whitelist: Sequence[str] = None,
     skiplist: Sequence[str] = None,
-) -> Tuple[int, str, Sequence[Error]]:
-    errors: Sequence[Error] = []
+) -> Tuple[int, str, List[Error]]:
+    errors: List[Error] = []
     ret = 0
 
     def _pycon_match(match: Match[str]) -> str:
@@ -258,7 +258,7 @@ def apply_pre_commit_pydocstring(
     return ret, src, errors
 
 
-def print_errors(errors: Sequence[Error]):
+def print_errors(errors: List[Error]):
     for error in errors:
         msg = []
         ctx = error.context

--- a/pre_commit_all_the_way_down/python_doc.py
+++ b/pre_commit_all_the_way_down/python_doc.py
@@ -149,7 +149,12 @@ def walk_ast_helper(
             + doc.splitlines()
             + newLines[doc_node.end_lineno :]
         )
-    return "\n".join(newLines) + "\n"
+
+    formatted = "\n".join(newLines) + "\n"
+    # Return an empty file if it is empty
+    if not formatted.strip():
+        return ""
+    return formatted
 
 
 def fake_indent(block: str, level: int) -> str:
@@ -238,6 +243,10 @@ def apply_pre_commit_pydocstring(
         code = "\n".join(
             line[len(head_ws) + 4 :] for line in match["content"].splitlines()
         )
+        # Special case for
+        # >>> # line with only a comment
+        if code.count("\n") == 0 and code.startswith("#"):
+            return match.group(0)
         code = fake_indent(code, len(head_ws) + 4)
         docStringStart = context.start if context.start is not None else 0
         start = docStringStart + offset_to_lineno(docStringSrc, match.start())

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -3,6 +3,7 @@ from tempfile import TemporaryDirectory
 from textwrap import dedent
 
 from pre_commit_all_the_way_down.python_doc import (
+    Context,
     apply_pre_commit_on_file,
     apply_pre_commit_rst,
 )
@@ -31,14 +32,19 @@ def test_format_from_string():
         """
     )
 
-    out = apply_pre_commit_rst(before, skiplist=["flake8"])
-    assert out == (0, after)
+    context = Context(filename="dummy")
+    (*out, _errors) = apply_pre_commit_rst(before, context=context, skiplist=["flake8"])
+    assert out == [0, after]
 
-    out = apply_pre_commit_rst(before, whitelist=["black", "isort"])
-    assert out == (0, after)
+    (*out, _errors) = apply_pre_commit_rst(
+        before, context=context, whitelist=["black", "isort"]
+    )
+    assert out == [0, after]
 
-    out = apply_pre_commit_rst(before, whitelist=["black", "isort", "flake8"])
-    assert out == (1, after)
+    (*out, _errors) = apply_pre_commit_rst(
+        before, context=context, whitelist=["black", "isort", "flake8"]
+    )
+    assert out == [1, after]
 
 
 def test_format_from_file():


### PR DESCRIPTION
This adds some niceties to report the error with the current context.

For example, imagine you have the following rst file:
```rst
.. python-script::

   import matplotlib
   matplotlib.use('Agg'))))
```
The following will be shown:
```
python-doc...............................................................Failed
- hook id: python-doc
- duration: 2.37s
- exit code: 1

Error in path/to/file.rst:130:160
STDOUT was:
 | pyupgrade................................................................Passed
 | black....................................................................Failed
 | - hook id: black
 | - exit code: 123
 | 
 | error: cannot format [...]/tmp/tmp1qk_lbpr/script.py: Cannot parse: 3:25:     matplotlib.use('Agg'))))
 | Oh no! 💥 💔 💥
 | 1 file failed to reformat.
 | 
 | isort....................................................................Passed
 | blacken-docs.............................................................Passed
STDERR was:
```